### PR TITLE
leaderelection: Set isLeader to false when resigning

### DIFF
--- a/locks.go
+++ b/locks.go
@@ -50,7 +50,7 @@ func (h *HAInstance) ResignLeader(ctx context.Context) error {
 		return err
 	}
 
-	h.isLeader = true
+	h.isLeader = false
 
 	return nil
 }


### PR DESCRIPTION
Currently this gets set to true regardless of resigning/becoming leader, which means the short circuiting in AmLeader never happens.